### PR TITLE
print out current time string after compile

### DIFF
--- a/app.js
+++ b/app.js
@@ -73,7 +73,7 @@ var watch_directory = argv.directory ? path.resolve(process.cwd(), argv.director
  * Compiles the less files given by the input and ouput options
  */
 function compileInput(){
-    console.log("watch-lessc: Updated: " + output_file);
+    console.log((new Date()).toTimeString() + " watch-lessc: Updated: " + output_file);
     fs.readFile(input_file, 'utf-8', lessc(input_file, output_file));
 }
 


### PR DESCRIPTION
I want to make sure it has been compiled. A lot of identical lines makes it hard to read. Maybe someone else also need this.

BTW: the node_module installed from npm is not the latest one? It didn't have a watch directory function. And that's why I want to check again and again.
